### PR TITLE
feat(event): Name the entity-state selectors, carry SE's handler names, rename two misleading steps

### DIFF
--- a/docs/events/authoring.md
+++ b/docs/events/authoring.md
@@ -257,7 +257,9 @@ Decoded from Bastok Markets (Isakoth 0x010EB0B1 event 26 + page routine 0x1866..
 Home Points, Voidwatch Purveyor). Register specs accepted everywhere a value or
 register is expected: `{"param": n}` (server parameter n = `Work_Zone[2+n]`, i.e.
 `startEvent` / `updateEvent` p_n), `{"work": n}`, `{"work1700": n}`, `{"local": n}`,
-`"result"` (Work_Zone[1]), `"menu_result"` (Work_Zone[0]); a bare integer is a constant.
+`"result"` (Work_Zone[1]), `"menu_result"` (Work_Zone[0]), `{"state": name}` (the client's
+runtime state selectors 0x7F00-0x7F8B: `player_race`, `player_job`, `player_level`, `event_x`, ...;
+the full list is in [typed_opcodes.md](typed_opcodes.md)); a bare integer is a constant.
 
 | step | emits | notes |
 |---|---|---|

--- a/docs/events/typed_opcodes.md
+++ b/docs/events/typed_opcodes.md
@@ -1,201 +1,205 @@
-## Typed retail opcodes (`xi_typed.TYPED`, 2026-09-05)
+## Typed retail opcodes (`xi_typed.TYPED`)
 
-One table drives both directions: `xi event decompile` emits these steps and the compiler writes them back byte for byte. Field kinds: `u8` / `u16` literal, `sel` selector (constant or register spec), `reg` register (a store target), `ent` entity id, `tag` four-char scheduler tag (`tagHex` when not printable), `name16` 16-byte name, `bytes[n]` literal hex, `tbl` a `table` label, `msg` a dialog line id. When an opcode has several forms, the compiler picks the one matching the step's fields (data length for `bytes`, the `sub` byte where the width depends on it). Semantics are XiEvents' (F:\XiEvents\OpCodes); names are ours.
+One table drives both directions: `xi event decompile` emits these steps and the compiler writes them back byte for byte. Field kinds: `u8` / `u16` literal, `sel` selector (constant through `references[]` or a register), `reg` register, `ent` entity id, `tag` scheduler tag, `name16` 16-byte name, `tbl` table label, `msg` dialog line, `bytes[n]` verbatim. The SE column is Square Enix's handler name where the PS2 client's symbols give one (the 2003 client ends at `0xA6`).
 
-| step | opcode | form | fields |
-|---|---|---|---|
-| `bit_and` | `0D` |  | `into`:reg, `value`:sel |
-| `bit_xor` | `0F` |  | `into`:reg, `value`:sel |
-| `blink` | `81` |  | `sub`:u8, `entity`:ent |
-| `byte_swap` | `19` |  | `into`:reg, `value`:sel |
-| `camera_control` | `46` | size 2 | `sub`:u8 |
-| `camera_control` | `46` | size 4 | `sub`:u8, `value`:sel |
-| `clear_motion` | `D3` |  | `sub`:u8, `entity`:ent |
-| `close_door` | `4D` |  | (none) |
-| `continue_off` | `30` |  | (none) |
-| `copy_string` | `C3` |  | `a`:sel, `data`:bytes[2], `b`:sel |
-| `cos` | `17` |  | `into`:reg, `a`:sel, `b`:sel |
-| `craft_op` | `8C` | size 10 | `sub`:u8, `a`:sel, `b`:sel, `c`:sel, `data`:bytes[2] |
-| `craft_op` | `8C` | size 12 | `sub`:u8, `a`:sel, `b`:sel, `c`:sel, `data`:bytes[4] |
-| `craft_op` | `8C` | size 14 | `sub`:u8, `a`:sel, `b`:sel, `c`:sel, `data`:bytes[6] |
-| `craft_op` | `8C` | size 2 | `sub`:u8 |
-| `craft_op` | `8C` | size 8 | `sub`:u8, `a`:sel, `b`:sel, `c`:sel |
-| `deprecated_56` | `56` |  | `data`:bytes[4] |
-| `deprecated_6d` | `6D` |  | `data`:bytes[6] |
-| `distance2d` | `64` |  | `into`:reg, `x1`:sel, `y1`:sel, `x2`:sel, `y2`:sel |
-| `distance3d` | `65` |  | `ent1`:ent, `ent2`:ent, `into`:reg |
-| `div` | `15` |  | `into`:reg, `value`:sel |
-| `effect_sub` | `C4` |  | `sub`:u8, `a`:sel, `ent1`:ent, `ent2`:ent |
-| `emote` | `6E` |  | `entity`:ent, `anim`:sel |
-| `entity_update` | `59` | sub 0x00 | `sub`:u8, `value`:sel |
-| `entity_update` | `59` | sub 0x01 | `sub`:u8, `entity`:ent, `value`:sel |
-| `entity_update` | `59` | sub 0x02 | `sub`:u8, `value`:sel |
-| `entity_update` | `59` | sub 0x03 | `sub`:u8, `entity`:ent, `value`:sel |
-| `entity_update` | `59` | sub 0x04 | `sub`:u8, `entity`:ent, `value`:sel |
-| `entity_update` | `59` | sub 0x05 | `sub`:u8, `entity`:ent, `value`:u8 |
-| `entity_update` | `59` | sub 0x06 | `sub`:u8, `entity`:ent |
-| `entity_update` | `59` | sub 0x07 | `sub`:u8, `value`:sel |
-| `entity_update` | `59` | sub 0x08 | `sub`:u8, `entity`:ent, `value`:sel |
-| `event_hide` | `22` |  | `flag`:u8 |
-| `event_mode` | `38` |  | `mode`:sel |
-| `event_npc_clear` | `96` |  | (none) |
-| `event_npc_set` | `95` |  | `value`:sel |
-| `event_pos` | `5A` | size 2 | `sub`:u8 |
-| `event_pos` | `5A` | size 8 | `sub`:u8, `x`:sel, `y`:sel, `z`:sel |
-| `event_pos_b` | `31` | size 10 | `sub`:u8, `x`:sel, `y`:sel, `z`:sel, `dir`:sel |
-| `event_pos_b` | `31` | size 2 | `sub`:u8 |
-| `event_status_45` | `8E` |  | (none) |
-| `event_weather` | `72` | size 10 | `sub`:u8, `a`:sel, `data`:bytes[6] |
-| `event_weather` | `72` | size 4 | `sub`:u8, `a`:sel |
-| `event_weather` | `72` | size 6 | `sub`:u8, `a`:sel, `b`:sel |
-| `fade_color` | `6C` |  | `entity`:ent, `a`:sel, `b`:sel |
-| `flag_d9` | `D9` |  | `flag`:u8 |
-| `frame_delay` | `57` |  | `into`:reg |
-| `get_flag_b1` | `B1` |  | `data`:bytes[3] |
-| `get_language` | `9C` |  | `into`:reg |
-| `get_pos` | `3B` |  | `entity`:ent, `x`:reg, `y`:reg, `z`:reg |
-| `get_time` | `83` |  | `into`:reg |
-| `get_yaw` | `3A` |  | `entity`:ent, `into`:reg |
-| `hud_hide` | `67` |  | `a`:sel, `b`:sel |
-| `hud_show` | `68` |  | (none) |
-| `if_entity_valid` | `44` |  | `entity`:ent |
-| `load_room` | `75` | size 2 | `sub`:u8 |
-| `load_room` | `75` | size 4 | `sub`:u8, `room`:sel |
-| `lock_player` | `20` |  | `flag`:u8 |
-| `look_op` | `B6` | size 14 | `sub`:u8, `a`:sel, `data`:bytes[10] |
-| `look_op` | `B6` | size 16 | `sub`:u8, `a`:sel, `data`:bytes[12] |
-| `look_op` | `B6` | size 2 | `sub`:u8 |
-| `look_op` | `B6` | size 20 | `sub`:u8, `a`:sel, `data`:bytes[16] |
-| `look_op` | `B6` | size 4 | `sub`:u8, `a`:sel |
-| `look_op` | `B6` | sub 0x0b | `sub`:u8, `race`:sel, `hair`:sel, `head`:sel, `body`:sel, `hands`:sel, `legs`:sel, `feet`:sel, `main`:sel, `sub2`:sel |
-| `look_op` | `B6` | sub 0x0d | `sub`:u8, `a`:sel, `race`:sel, `body`:sel, `head`:sel, `feet`:sel, `hands`:sel |
-| `look_op` | `B6` | sub 0x0e | `sub`:u8, `a`:sel, `race`:sel, `body`:sel, `head`:sel, `feet`:sel, `hands`:sel, `legs`:sel |
-| `look_op` | `B6` | sub 0x14 | `sub`:u8, `entity`:ent |
-| `look_op` | `B6` | sub 0x15 | `sub`:u8, `entity`:ent |
-| `map_close` | `8A` |  | (none) |
-| `map_marker` | `8B` |  | `a`:sel, `b`:sel, `c`:sel, `d`:sel, `name`:name16 |
-| `map_markers` | `A8` |  | `sub`:u8, `a`:sel, `b`:sel |
-| `map_markers_add` | `B8` |  | `a`:sel, `b`:sel, `c`:sel, `d`:sel, `e`:sel, `name`:name16 |
-| `map_open` | `89` |  | `map`:sel |
-| `map_open_params` | `C8` |  | `a`:sel, `b`:sel, `c`:sel |
-| `map_open_props` | `8D` |  | `a`:sel, `b`:sel |
-| `misc_ae` | `AE` | size 10 | `sub`:u8, `data`:bytes[8] |
-| `misc_ae` | `AE` | size 6 | `sub`:u8, `data`:bytes[4] |
-| `misc_ae` | `AE` | size 8 | `sub`:u8, `data`:bytes[4], `a`:sel |
-| `mount_op` | `7E` | size 16 | `sub`:u8, `entity`:ent, `a`:sel, `b`:sel, `c`:sel, `d`:sel, `e`:sel |
-| `mount_op` | `7E` | size 18 | `sub`:u8, `entity`:ent, `a`:sel, `b`:sel, `c`:sel, `d`:sel, `e`:sel, `f`:sel |
-| `mount_op` | `7E` | size 6 | `sub`:u8, `entity`:ent |
-| `mount_op` | `7E` | size 8 | `sub`:u8, `entity`:ent, `a`:sel |
-| `music_op` | `5C` | size 4 | `sub`:u8, `a`:sel |
-| `music_op` | `5C` | size 6 | `sub`:u8, `a`:sel, `b`:sel |
-| `music_vol` | `5D` |  | `volume`:sel, `frames`:sel |
-| `op_ac` | `AC` | size 4 | `sub`:u8, `a`:sel |
-| `op_ac` | `AC` | size 6 | `sub`:u8, `data`:bytes[4] |
-| `op_ac` | `AC` | size 8 | `sub`:u8, `data`:bytes[4], `a`:sel |
-| `op_c2` | `C2` | size 2 | `sub`:u8 |
-| `op_c2` | `C2` | size 4 | `sub`:u8, `data`:bytes[2] |
-| `op_c2` | `C2` | size 6 | `sub`:u8, `a`:sel, `data`:bytes[2] |
-| `op_d8` | `D8` | size 12 | `sub`:u8, `data`:bytes[4], `a`:sel, `b`:sel, `c`:sel |
-| `op_d8` | `D8` | size 6 | `sub`:u8, `data`:bytes[4] |
-| `op_d8` | `D8` | size 8 | `sub`:u8, `data`:bytes[4], `a`:sel |
-| `open_door` | `4C` |  | (none) |
-| `play_anim_wait` | `63` |  | `anim`:sel |
-| `player_task` | `7D` |  | `task`:sel |
-| `print_to` | `B0` |  | `sub`:u8, `speaker`:ent, `listener`:ent, `text`:msg |
-| `query_op` | `D4` | size 8 | `sub`:u8, `a`:sel, `b`:sel, `c`:sel |
-| `rand_mod` | `13` |  | `into`:reg, `value`:sel |
-| `rank_board` | `B3` | size 14 | `sub`:u8, `a`:sel, `b`:sel, `c`:sel, `d`:sel, `e`:sel, `f`:sel |
-| `rank_board` | `B3` | size 18 | `sub`:u8, `a`:sel, `b`:sel, `c`:sel, `d`:sel, `e`:sel, `f`:sel, `g`:sel, `h`:sel |
-| `rank_board` | `B3` | size 2 | `sub`:u8 |
-| `rank_board` | `B3` | size 4 | `sub`:u8, `a`:sel |
-| `rect_send_flag` | `9E` |  | `flag`:u8 |
-| `render_flags0` | `2F` |  | `flag`:u8, `entity`:ent |
-| `render_flags2` | `7C` |  | `flag`:u8, `entity`:ent |
-| `render_flags3` | `94` |  | `flag`:u8, `entity`:ent |
-| `render_flags3_b` | `86` |  | `flag`:u8, `entity`:ent |
-| `render_sub` | `AB` | size 2 | `sub`:u8 |
-| `render_sub` | `AB` | size 4 | `sub`:u8, `a`:sel |
-| `render_sub` | `AB` | size 6 | `sub`:u8, `entity`:ent |
-| `request` | `27` |  | `a`:u8, `entity`:ent, `b`:u8 |
-| `request_b` | `28` |  | `a`:u8, `entity`:ent, `b`:u8 |
-| `request_wait` | `2A` |  | `a`:u8, `entity`:ent |
-| `reset_time` | `78` |  | (none) |
-| `sched_5f` | `5F` | sub 0x00 | `sub`:u8 |
-| `sched_5f` | `5F` | sub 0x01 | `sub`:u8 |
-| `sched_5f` | `5F` | sub 0x02 | `sub`:u8, `entity`:ent |
-| `sched_5f` | `5F` | sub 0x03 | `sub`:u8, `a`:sel, `ent1`:ent, `ent2`:ent, `tag`:tag |
-| `sched_5f` | `5F` | sub 0x04 | `sub`:u8, `a`:sel, `ent1`:ent, `ent2`:ent, `tag`:tag |
-| `sched_5f` | `5F` | sub 0x05 | `sub`:u8, `a`:sel, `ent1`:ent, `ent2`:ent, `tag`:tag, `b`:sel |
-| `sched_5f` | `5F` | sub 0x06 | `sub`:u8, `a`:sel, `ent1`:ent, `ent2`:ent, `tag`:tag, `b`:sel |
-| `sched_5f` | `5F` | sub 0x07 | `sub`:u8, `ent1`:ent, `ent2`:ent, `tag`:tag |
-| `sched_action` | `AD` |  | `sub`:u8, `a`:sel, `ent1`:ent, `ent2`:ent |
-| `self_flags0` | `33` |  | `flag`:u8 |
-| `self_flags01` | `90` |  | (none) |
-| `self_flags1` | `74` |  | `flag`:u8 |
-| `self_flags2` | `61` |  | `flag`:u8 |
-| `self_flags3_a` | `A4` |  | `flag`:u8 |
-| `self_flags3_b` | `A5` |  | `flag`:u8 |
-| `self_flags3_c` | `C0` |  | `value`:sel |
-| `set_dir` | `39` |  | `dir`:sel |
-| `set_name` | `B5` |  | `data`:bytes[3] |
-| `set_pos3` | `36` |  | `x`:sel, `z`:sel, `y`:sel |
-| `set_speed` | `32` |  | `speed`:sel |
-| `set_status_event` | `4F` |  | `value`:sel |
-| `set_time` | `77` |  | `time`:sel, `weather`:sel |
-| `set_wind` | `97` |  | `base`:sel, `width`:sel |
-| `set_yaw` | `4B` |  | `entity`:ent, `yaw`:sel |
-| `shr` | `11` |  | `into`:reg, `value`:sel |
-| `sin` | `16` |  | `into`:reg, `a`:sel, `b`:sel |
-| `sound_volume` | `69` |  | `kind`:u8, `volume`:sel |
-| `sound_volume_ease` | `6A` |  | `a`:sel, `b`:sel, `c`:sel |
-| `stop_action` | `5E` |  | `tag`:tag |
-| `stop_action_of` | `6B` |  | `tag`:tag, `entity`:ent |
-| `stop_talking` | `7B` |  | `entity`:ent |
-| `subtract` | `08` |  | `into`:reg, `value`:sel |
-| `table_op` | `9D` | sub 0x0a | `sub`:u8, `table`:tbl, `n`:u16, `a`:sel, `b`:sel |
-| `table_op` | `9D` | sub 0x0b | `sub`:u8, `table`:tbl, `n`:u16, `a`:sel, `b`:sel |
-| `table_op` | `9D` | sub 0x0c | `sub`:u8, `table`:tbl, `a`:sel, `b`:sel |
-| `table_op` | `9D` | sub 0x0f | `sub`:u8, `table`:tbl, `a`:sel, `b`:sel, `c`:sel |
-| `table_op` | `9D` | sub 0x10 | `sub`:u8, `table`:tbl, `n`:u16, `a`:sel, `b`:sel |
-| `task_62` | `62` |  | `a`:sel, `ent1`:ent, `ent2`:ent, `tag`:tag, `b`:sel |
-| `task_9f` | `9F` |  | `a`:sel, `ent1`:ent, `ent2`:ent, `tag`:tag, `b`:sel |
-| `task_bb` | `BB` |  | `a`:sel, `ent1`:ent, `ent2`:ent, `tag`:tag, `b`:sel |
-| `task_c5` | `C5` |  | `a`:sel, `ent1`:ent, `ent2`:ent, `tag`:tag, `b`:sel |
-| `task_cd` | `CD` |  | `a`:sel, `ent1`:ent, `ent2`:ent, `tag`:tag, `b`:sel |
-| `task_d0` | `D0` |  | `a`:sel, `ent1`:ent, `ent2`:ent, `tag`:tag, `b`:sel |
-| `task_d5` | `D5` |  | `a`:sel, `ent1`:ent, `ent2`:ent, `tag`:tag, `b`:sel |
-| `ui_op` | `B4` | size 2 | `sub`:u8 |
-| `ui_op` | `B4` | size 20 | `sub`:u8, `into`:reg, `text`:name16 |
-| `ui_op` | `B4` | size 3 | `sub`:u8, `value`:u8 |
-| `ui_op` | `B4` | size 4 | `sub`:u8, `a`:sel |
-| `ui_op` | `B4` | size 6 | `sub`:u8, `a`:sel, `b`:sel |
-| `update_pos_sv` | `47` | size 10 | `sub`:u8, `x`:sel, `y`:sel, `z`:sel, `dir`:sel |
-| `update_pos_sv` | `47` | size 2 | `sub`:u8 |
-| `vana_time` | `AA` |  | `time`:sel, `year`:reg, `month`:reg, `day`:reg, `weekday`:reg, `hour`:reg, `minute`:reg, `moon`:reg |
-| `vm_reset` | `7A` | size 6 | `sub`:u8, `entity`:ent |
-| `vm_reset` | `7A` | sub 0x00 | `sub`:u8, `entity`:ent |
-| `vm_reset` | `7A` | sub 0x01 | `sub`:u8, `entity`:ent, `value`:u8 |
-| `vm_reset` | `7A` | sub 0x02 | `sub`:u8, `entity`:ent |
-| `vm_reset` | `7A` | sub 0x03 | `sub`:u8 |
-| `vm_reset` | `7A` | sub 0x04 | `sub`:u8, `a`:u8, `entity`:ent, `b`:u8 |
-| `vm_reset` | `7A` | sub 0x05 | `sub`:u8, `entity`:ent |
-| `wait_a0` | `A0` |  | `a`:sel, `ent1`:ent, `ent2`:ent, `tag`:tag |
-| `wait_a2` | `A2` |  | `a`:sel, `ent1`:ent, `ent2`:ent, `tag`:tag |
-| `wait_anim` | `99` |  | `entity`:ent |
-| `wait_bc` | `BC` |  | `a`:sel, `ent1`:ent, `ent2`:ent, `tag`:tag |
-| `wait_c6` | `C6` |  | `a`:sel, `ent1`:ent, `ent2`:ent, `tag`:tag |
-| `wait_ce` | `CE` |  | `a`:sel, `ent1`:ent, `ent2`:ent, `tag`:tag |
-| `wait_music` | `9A` |  | (none) |
-| `wait_render` | `76` |  | `entity`:ent |
-| `wait_self_anim` | `9B` |  | (none) |
-| `wait_server_req` | `A7` | size 2 | `sub`:u8 |
-| `wait_server_req` | `A7` | size 4 | `sub`:u8, `value`:sel |
-| `wait_zone_load` | `98` |  | (none) |
-| `wait_zone_task` | `54` |  | `ent1`:ent, `ent2`:ent, `tag`:tag |
-| `worldpass_a` | `87` |  | `sub`:u8 |
-| `worldpass_b` | `88` |  | `sub`:u8 |
-| `yield` | `58` |  | (none) |
-| `zone_load` | `34` |  | `zone`:sel |
-| `zone_load2` | `35` |  | `zone`:sel |
-| `zone_task` | `2D` |  | `ent1`:ent, `ent2`:ent, `tag`:tag |
-| `zone_task_end` | `51` |  | `ent1`:ent, `ent2`:ent, `tag`:tag |
+| step | opcode | form | fields | SE handler |
+|---|---|---|---|---|
+| `bit_and` | `0D` |  | `into`:reg, `value`:sel |  |
+| `bit_xor` | `0F` |  | `into`:reg, `value`:sel |  |
+| `blink` | `81` |  | `sub`:u8, `entity`:ent |  |
+| `byte_swap` | `19` |  | `into`:reg, `value`:sel |  |
+| `camera_control` | `46` | size 2 | `sub`:u8 | CodeDEFCAMERA |
+| `camera_control` | `46` | size 4 | `sub`:u8, `value`:sel | CodeDEFCAMERA |
+| `clear_motion` | `D3` |  | `sub`:u8, `entity`:ent |  |
+| `close_door` | `4D` |  |  |  |
+| `continue_off` | `30` |  |  |  |
+| `copy_string` | `C3` |  | `a`:sel, `data`:bytes[2], `b`:sel |  |
+| `cos` | `17` |  | `into`:reg, `a`:sel, `b`:sel |  |
+| `craft_op` | `8C` | size 10 | `sub`:u8, `a`:sel, `b`:sel, `c`:sel, `data`:bytes[2] |  |
+| `craft_op` | `8C` | size 12 | `sub`:u8, `a`:sel, `b`:sel, `c`:sel, `data`:bytes[4] |  |
+| `craft_op` | `8C` | size 14 | `sub`:u8, `a`:sel, `b`:sel, `c`:sel, `data`:bytes[6] |  |
+| `craft_op` | `8C` | size 2 | `sub`:u8 |  |
+| `craft_op` | `8C` | size 8 | `sub`:u8, `a`:sel, `b`:sel, `c`:sel |  |
+| `deprecated_56` | `56` |  | `data`:bytes[4] |  |
+| `deprecated_6d` | `6D` |  | `data`:bytes[6] |  |
+| `distance2d` | `64` |  | `into`:reg, `x1`:sel, `y1`:sel, `x2`:sel, `y2`:sel |  |
+| `distance3d` | `65` |  | `ent1`:ent, `ent2`:ent, `into`:reg | CodeGETDISTANCEAA |
+| `div` | `15` |  | `into`:reg, `value`:sel |  |
+| `effect_sub` | `C4` |  | `sub`:u8, `a`:sel, `ent1`:ent, `ent2`:ent |  |
+| `emote` | `6E` |  | `entity`:ent, `anim`:sel | CodeEMOT |
+| `entity_update` | `59` | sub 00 | `sub`:u8, `value`:sel |  |
+| `entity_update` | `59` | sub 01 | `sub`:u8, `entity`:ent, `value`:sel |  |
+| `entity_update` | `59` | sub 02 | `sub`:u8, `value`:sel |  |
+| `entity_update` | `59` | sub 03 | `sub`:u8, `entity`:ent, `value`:sel |  |
+| `entity_update` | `59` | sub 04 | `sub`:u8, `entity`:ent, `value`:sel |  |
+| `entity_update` | `59` | sub 05 | `sub`:u8, `entity`:ent, `value`:u8 |  |
+| `entity_update` | `59` | sub 06 | `sub`:u8, `entity`:ent |  |
+| `entity_update` | `59` | sub 07 | `sub`:u8, `value`:sel |  |
+| `entity_update` | `59` | sub 08 | `sub`:u8, `entity`:ent, `value`:sel |  |
+| `event_hide` | `22` |  | `flag`:u8 |  |
+| `event_mode` | `38` |  | `mode`:sel |  |
+| `event_npc_clear` | `96` |  |  |  |
+| `event_npc_set` | `95` |  | `value`:sel |  |
+| `event_pos` | `5A` | size 2 | `sub`:u8 | CodeMOVE2 |
+| `event_pos` | `5A` | size 8 | `sub`:u8, `x`:sel, `y`:sel, `z`:sel | CodeMOVE2 |
+| `event_pos_b` | `31` | size 10 | `sub`:u8, `x`:sel, `y`:sel, `z`:sel, `dir`:sel | CodeSMOVE |
+| `event_pos_b` | `31` | size 2 | `sub`:u8 | CodeSMOVE |
+| `event_status_45` | `8E` |  |  |  |
+| `event_weather` | `72` | size 10 | `sub`:u8, `a`:sel, `data`:bytes[6] | CodeGETWEATER |
+| `event_weather` | `72` | size 4 | `sub`:u8, `a`:sel | CodeGETWEATER |
+| `event_weather` | `72` | size 6 | `sub`:u8, `a`:sel, `b`:sel | CodeGETWEATER |
+| `flag_d9` | `D9` |  | `flag`:u8 |  |
+| `frame_delay` | `57` |  | `into`:reg |  |
+| `get_flag_b1` | `B1` |  | `data`:bytes[3] |  |
+| `get_language` | `9C` |  | `into`:reg |  |
+| `get_pos` | `3B` |  | `entity`:ent, `x`:reg, `y`:reg, `z`:reg |  |
+| `get_time` | `83` |  | `into`:reg |  |
+| `get_yaw` | `3A` |  | `entity`:ent, `into`:reg |  |
+| `hud_hide` | `67` |  | `a`:sel, `b`:sel |  |
+| `hud_show` | `68` |  |  |  |
+| `if_entity_valid` | `44` |  | `entity`:ent |  |
+| `load_room` | `75` | size 2 | `sub`:u8 | CodeLOADROOM |
+| `load_room` | `75` | size 4 | `sub`:u8, `room`:sel | CodeLOADROOM |
+| `lock_player` | `20` |  | `flag`:u8 |  |
+| `look_op` | `B6` | size 14 | `sub`:u8, `a`:sel, `data`:bytes[10] |  |
+| `look_op` | `B6` | size 16 | `sub`:u8, `a`:sel, `data`:bytes[12] |  |
+| `look_op` | `B6` | size 2 | `sub`:u8 |  |
+| `look_op` | `B6` | size 20 | `sub`:u8, `a`:sel, `data`:bytes[16] |  |
+| `look_op` | `B6` | size 4 | `sub`:u8, `a`:sel |  |
+| `look_op` | `B6` | sub 0B | `sub`:u8, `race`:sel, `hair`:sel, `head`:sel, `body`:sel, `hands`:sel, `legs`:sel, `feet`:sel, `main`:sel, `sub2`:sel |  |
+| `look_op` | `B6` | sub 0D | `sub`:u8, `a`:sel, `race`:sel, `body`:sel, `head`:sel, `feet`:sel, `hands`:sel |  |
+| `look_op` | `B6` | sub 0E | `sub`:u8, `a`:sel, `race`:sel, `body`:sel, `head`:sel, `feet`:sel, `hands`:sel, `legs`:sel |  |
+| `look_op` | `B6` | sub 14 | `sub`:u8, `entity`:ent |  |
+| `look_op` | `B6` | sub 15 | `sub`:u8, `entity`:ent |  |
+| `map_close` | `8A` |  |  |  |
+| `map_marker` | `8B` |  | `a`:sel, `b`:sel, `c`:sel, `d`:sel, `name`:name16 | CodeSETEVENTMARK |
+| `map_markers` | `A8` |  | `sub`:u8, `a`:sel, `b`:sel |  |
+| `map_markers_add` | `B8` |  | `a`:sel, `b`:sel, `c`:sel, `d`:sel, `e`:sel, `name`:name16 |  |
+| `map_open` | `89` |  | `map`:sel |  |
+| `map_open_params` | `C8` |  | `a`:sel, `b`:sel, `c`:sel |  |
+| `map_open_props` | `8D` |  | `a`:sel, `b`:sel |  |
+| `misc_ae` | `AE` | size 10 | `sub`:u8, `data`:bytes[8] |  |
+| `misc_ae` | `AE` | size 6 | `sub`:u8, `data`:bytes[4] |  |
+| `misc_ae` | `AE` | size 8 | `sub`:u8, `data`:bytes[4], `a`:sel |  |
+| `mount_op` | `7E` | size 16 | `sub`:u8, `entity`:ent, `a`:sel, `b`:sel, `c`:sel, `d`:sel, `e`:sel | CodeCHOCOBO |
+| `mount_op` | `7E` | size 18 | `sub`:u8, `entity`:ent, `a`:sel, `b`:sel, `c`:sel, `d`:sel, `e`:sel, `f`:sel | CodeCHOCOBO |
+| `mount_op` | `7E` | size 6 | `sub`:u8, `entity`:ent | CodeCHOCOBO |
+| `mount_op` | `7E` | size 8 | `sub`:u8, `entity`:ent, `a`:sel | CodeCHOCOBO |
+| `music_op` | `5C` | size 4 | `sub`:u8, `a`:sel |  |
+| `music_op` | `5C` | size 6 | `sub`:u8, `a`:sel, `b`:sel |  |
+| `music_vol` | `5D` |  | `volume`:sel, `frames`:sel |  |
+| `op_ac` | `AC` | size 4 | `sub`:u8, `a`:sel |  |
+| `op_ac` | `AC` | size 6 | `sub`:u8, `data`:bytes[4] |  |
+| `op_ac` | `AC` | size 8 | `sub`:u8, `data`:bytes[4], `a`:sel |  |
+| `op_c2` | `C2` | size 2 | `sub`:u8 |  |
+| `op_c2` | `C2` | size 4 | `sub`:u8, `data`:bytes[2] |  |
+| `op_c2` | `C2` | size 6 | `sub`:u8, `a`:sel, `data`:bytes[2] |  |
+| `op_d8` | `D8` | size 12 | `sub`:u8, `data`:bytes[4], `a`:sel, `b`:sel, `c`:sel |  |
+| `op_d8` | `D8` | size 6 | `sub`:u8, `data`:bytes[4] |  |
+| `op_d8` | `D8` | size 8 | `sub`:u8, `data`:bytes[4], `a`:sel |  |
+| `open_door` | `4C` |  |  |  |
+| `play_anim_wait` | `63` |  | `anim`:sel |  |
+| `player_task` | `7D` |  | `task`:sel |  |
+| `print_to` | `B0` |  | `sub`:u8, `speaker`:ent, `listener`:ent, `text`:msg |  |
+| `query_op` | `D4` | size 8 | `sub`:u8, `a`:sel, `b`:sel, `c`:sel |  |
+| `rand_mod` | `13` |  | `into`:reg, `value`:sel |  |
+| `rank_board` | `B3` | size 14 | `sub`:u8, `a`:sel, `b`:sel, `c`:sel, `d`:sel, `e`:sel, `f`:sel |  |
+| `rank_board` | `B3` | size 18 | `sub`:u8, `a`:sel, `b`:sel, `c`:sel, `d`:sel, `e`:sel, `f`:sel, `g`:sel, `h`:sel |  |
+| `rank_board` | `B3` | size 2 | `sub`:u8 |  |
+| `rank_board` | `B3` | size 4 | `sub`:u8, `a`:sel |  |
+| `rect_send_flag` | `9E` |  | `flag`:u8 |  |
+| `render_flags0` | `2F` |  | `flag`:u8, `entity`:ent |  |
+| `render_flags2` | `7C` |  | `flag`:u8, `entity`:ent |  |
+| `render_flags3` | `94` |  | `flag`:u8, `entity`:ent |  |
+| `render_flags3_b` | `86` |  | `flag`:u8, `entity`:ent |  |
+| `render_sub` | `AB` | size 2 | `sub`:u8 |  |
+| `render_sub` | `AB` | size 4 | `sub`:u8, `a`:sel |  |
+| `render_sub` | `AB` | size 6 | `sub`:u8, `entity`:ent |  |
+| `request` | `27` |  | `a`:u8, `entity`:ent, `b`:u8 |  |
+| `request_b` | `28` |  | `a`:u8, `entity`:ent, `b`:u8 | CodeREQSW |
+| `request_level` | `2A` |  | `a`:u8, `entity`:ent |  |
+| `reset_time` | `78` |  |  |  |
+| `sched_5f` | `5F` | sub 00 | `sub`:u8 |  |
+| `sched_5f` | `5F` | sub 01 | `sub`:u8 |  |
+| `sched_5f` | `5F` | sub 02 | `sub`:u8, `entity`:ent |  |
+| `sched_5f` | `5F` | sub 03 | `sub`:u8, `a`:sel, `ent1`:ent, `ent2`:ent, `tag`:tag |  |
+| `sched_5f` | `5F` | sub 04 | `sub`:u8, `a`:sel, `ent1`:ent, `ent2`:ent, `tag`:tag |  |
+| `sched_5f` | `5F` | sub 05 | `sub`:u8, `a`:sel, `ent1`:ent, `ent2`:ent, `tag`:tag, `b`:sel |  |
+| `sched_5f` | `5F` | sub 06 | `sub`:u8, `a`:sel, `ent1`:ent, `ent2`:ent, `tag`:tag, `b`:sel |  |
+| `sched_5f` | `5F` | sub 07 | `sub`:u8, `ent1`:ent, `ent2`:ent, `tag`:tag |  |
+| `sched_action` | `AD` |  | `sub`:u8, `a`:sel, `ent1`:ent, `ent2`:ent |  |
+| `self_flags0` | `33` |  | `flag`:u8 |  |
+| `self_flags01` | `90` |  |  |  |
+| `self_flags1` | `74` |  | `flag`:u8 |  |
+| `self_flags2` | `61` |  | `flag`:u8 |  |
+| `self_flags3_a` | `A4` |  | `flag`:u8 |  |
+| `self_flags3_b` | `A5` |  | `flag`:u8 |  |
+| `self_flags3_c` | `C0` |  | `value`:sel |  |
+| `set_dir` | `39` |  | `dir`:sel |  |
+| `set_name` | `B5` |  | `data`:bytes[3] |  |
+| `set_pos3` | `36` |  | `x`:sel, `z`:sel, `y`:sel |  |
+| `set_speed` | `32` |  | `speed`:sel |  |
+| `set_status_event` | `4F` |  | `value`:sel |  |
+| `set_time` | `77` |  | `time`:sel, `weather`:sel |  |
+| `set_wind` | `97` |  | `base`:sel, `width`:sel |  |
+| `set_yaw` | `4B` |  | `entity`:ent, `yaw`:sel |  |
+| `shr` | `11` |  | `into`:reg, `value`:sel |  |
+| `sin` | `16` |  | `into`:reg, `a`:sel, `b`:sel |  |
+| `sound_volume` | `69` |  | `kind`:u8, `volume`:sel |  |
+| `sound_volume_ease` | `6A` |  | `a`:sel, `b`:sel, `c`:sel |  |
+| `stop_action` | `5E` |  | `tag`:tag |  |
+| `stop_action_of` | `6B` |  | `tag`:tag, `entity`:ent |  |
+| `stop_talking` | `7B` |  | `entity`:ent |  |
+| `subtract` | `08` |  | `into`:reg, `value`:sel |  |
+| `table_op` | `9D` | sub 0A | `sub`:u8, `table`:tbl, `n`:u16, `a`:sel, `b`:sel |  |
+| `table_op` | `9D` | sub 0B | `sub`:u8, `table`:tbl, `n`:u16, `a`:sel, `b`:sel |  |
+| `table_op` | `9D` | sub 0C | `sub`:u8, `table`:tbl, `a`:sel, `b`:sel |  |
+| `table_op` | `9D` | sub 0F | `sub`:u8, `table`:tbl, `a`:sel, `b`:sel, `c`:sel |  |
+| `table_op` | `9D` | sub 10 | `sub`:u8, `table`:tbl, `n`:u16, `a`:sel, `b`:sel |  |
+| `task_62` | `62` |  | `a`:sel, `ent1`:ent, `ent2`:ent, `tag`:tag, `b`:sel | CodeLOADEVENTSCHEDULER |
+| `task_9f` | `9F` |  | `a`:sel, `ent1`:ent, `ent2`:ent, `tag`:tag, `b`:sel | CodeLOADEVENTSCHEDULER2 |
+| `task_bb` | `BB` |  | `a`:sel, `ent1`:ent, `ent2`:ent, `tag`:tag, `b`:sel |  |
+| `task_c5` | `C5` |  | `a`:sel, `ent1`:ent, `ent2`:ent, `tag`:tag, `b`:sel |  |
+| `task_cd` | `CD` |  | `a`:sel, `ent1`:ent, `ent2`:ent, `tag`:tag, `b`:sel |  |
+| `task_d0` | `D0` |  | `a`:sel, `ent1`:ent, `ent2`:ent, `tag`:tag, `b`:sel |  |
+| `task_d5` | `D5` |  | `a`:sel, `ent1`:ent, `ent2`:ent, `tag`:tag, `b`:sel |  |
+| `transparency` | `6C` |  | `entity`:ent, `a`:sel, `b`:sel | CodeTRANSPAR |
+| `ui_op` | `B4` | size 2 | `sub`:u8 |  |
+| `ui_op` | `B4` | size 20 | `sub`:u8, `into`:reg, `text`:name16 |  |
+| `ui_op` | `B4` | size 3 | `sub`:u8, `value`:u8 |  |
+| `ui_op` | `B4` | size 4 | `sub`:u8, `a`:sel |  |
+| `ui_op` | `B4` | size 6 | `sub`:u8, `a`:sel, `b`:sel |  |
+| `update_pos_sv` | `47` | size 10 | `sub`:u8, `x`:sel, `y`:sel, `z`:sel, `dir`:sel |  |
+| `update_pos_sv` | `47` | size 2 | `sub`:u8 |  |
+| `vana_time` | `AA` |  | `time`:sel, `year`:reg, `month`:reg, `day`:reg, `weekday`:reg, `hour`:reg, `minute`:reg, `moon`:reg |  |
+| `vm_reset` | `7A` | size 6 | `sub`:u8, `entity`:ent |  |
+| `vm_reset` | `7A` | sub 00 | `sub`:u8, `entity`:ent |  |
+| `vm_reset` | `7A` | sub 01 | `sub`:u8, `entity`:ent, `value`:u8 |  |
+| `vm_reset` | `7A` | sub 02 | `sub`:u8, `entity`:ent |  |
+| `vm_reset` | `7A` | sub 03 | `sub`:u8 |  |
+| `vm_reset` | `7A` | sub 04 | `sub`:u8, `a`:u8, `entity`:ent, `b`:u8 |  |
+| `vm_reset` | `7A` | sub 05 | `sub`:u8, `entity`:ent |  |
+| `wait_a0` | `A0` |  | `a`:sel, `ent1`:ent, `ent2`:ent, `tag`:tag | CodeWAITLOADSCHEDULER_Main |
+| `wait_a2` | `A2` |  | `a`:sel, `ent1`:ent, `ent2`:ent, `tag`:tag | CodeWAITLOADSCHEDULER_Main |
+| `wait_anim` | `99` |  | `entity`:ent |  |
+| `wait_bc` | `BC` |  | `a`:sel, `ent1`:ent, `ent2`:ent, `tag`:tag |  |
+| `wait_c6` | `C6` |  | `a`:sel, `ent1`:ent, `ent2`:ent, `tag`:tag |  |
+| `wait_ce` | `CE` |  | `a`:sel, `ent1`:ent, `ent2`:ent, `tag`:tag |  |
+| `wait_music` | `9A` |  |  |  |
+| `wait_render` | `76` |  | `entity`:ent |  |
+| `wait_self_anim` | `9B` |  |  |  |
+| `wait_server_req` | `A7` | size 2 | `sub`:u8 |  |
+| `wait_server_req` | `A7` | size 4 | `sub`:u8, `value`:sel |  |
+| `wait_zone_load` | `98` |  |  | XiZone::IsReadingExtData |
+| `wait_zone_task` | `54` |  | `ent1`:ent, `ent2`:ent, `tag`:tag | CodeWAITMAPSCHEDULOR |
+| `worldpass_a` | `87` |  | `sub`:u8 |  |
+| `worldpass_b` | `88` |  | `sub`:u8 |  |
+| `yield` | `58` |  |  |  |
+| `zone_load` | `34` |  | `zone`:sel | XiZone::Open |
+| `zone_load2` | `35` |  | `zone`:sel | XiZone::Open (no close) |
+| `zone_task` | `2D` |  | `ent1`:ent, `ent2`:ent, `tag`:tag | CodeMAPSCHEDULOR |
+| `zone_task_end` | `51` |  | `ent1`:ent, `ent2`:ent, `tag`:tag | CodeENDMAPSCHEDULOR |
+
+Old names still accepted by the compiler: `companion` -> `request_wait`, `fade_color` -> `transparency`.
+
+Entity-state selectors, carried as `{"state": name}` wherever a register is accepted: `event_x` = `7F00`, `event_z` = `7F01`, `event_y` = `7F02`, `event_dir` = `7F03`, `event_job` = `7F06`, `event_race` = `7F07`, `event_level` = `7F08`, `event_server_id` = `7F0A`, `event_flag25` = `7F0B`, `player_x` = `7F80`, `player_z` = `7F81`, `player_y` = `7F82`, `player_dir` = `7F83`, `player_job` = `7F86`, `player_race` = `7F87`, `player_level` = `7F88`, `player_server_id` = `7F8A`, `player_flag25` = `7F8B`.

--- a/src/xi/event/xi_compile.py
+++ b/src/xi/event/xi_compile.py
@@ -1073,13 +1073,15 @@ def _work_selector(spec) -> int:
             return 0x1700 + int(spec["work1700"])
         if "local" in spec and 0 <= int(spec["local"]) < 0x1000:
             return int(spec["local"])
+        if "state" in spec and spec["state"] in xi_typed.STATE_SELECTORS:
+            return xi_typed.STATE_SELECTORS[spec["state"]]   # entity / local-player runtime state (0x7F00-0x7F8B)
         if "sel" in spec and 0 <= int(spec["sel"]) <= 0xFFFF:
             return int(spec["sel"])            # a raw selector the decompiler could not name (retail
                                                # occasionally writes an immediate ref where a register goes)
     if isinstance(spec, int) and 0 <= spec < 0x100:
         return WORK_ZONE_BASE + spec
     raise CutsceneCompileError(
-        f"register spec must be 'menu_result', {{'param': n}}, {{'work': n}}, {{'work1700': n}} or {{'local': n}}, got {spec!r}")
+        f"register spec must be 'menu_result', {{'param': n}}, {{'work': n}}, {{'work1700': n}}, {{'local': n}} or {{'state': name}}, got {spec!r}")
 
 
 def _value_selector(ctx: _Ctx, spec) -> int:
@@ -2288,6 +2290,7 @@ STEP_DISPATCH: dict[str, Callable] = {
     "look": _step_look,
     "look_at": _step_look_at,
     "companion": _step_companion,
+    "request_wait": _step_companion,
     "action": _step_action,
     "wait_task": _step_wait_task,
     "schedule": _step_schedule,
@@ -2320,6 +2323,9 @@ STEP_DISPATCH: dict[str, Callable] = {
 }
 for _typed_name in xi_typed.NAMES:
     STEP_DISPATCH[_typed_name] = _step_typed          # retail-shaped fixed-layout opcodes
+for _old, _new in xi_typed.ALIASES.items():           # renamed steps: old JSON keeps compiling
+    if _new in STEP_DISPATCH:
+        STEP_DISPATCH[_old] = STEP_DISPATCH[_new]
 
 
 # ---------------------------------------------------------------------------

--- a/src/xi/event/xi_decompile.py
+++ b/src/xi/event/xi_decompile.py
@@ -353,6 +353,8 @@ class Ctx:
             return {"work": sel - 0x1000}
         if sel < 0x1000:
             return {"local": sel}
+        if sel in xi_typed.STATE_NAMES:
+            return {"state": xi_typed.STATE_NAMES[sel]}   # entity / local-player runtime state
         return {"sel": sel}           # unnamed selector bank: carried verbatim
 
     def is_const(self, sel: int) -> bool:
@@ -659,7 +661,7 @@ def decode_op(ctx: Ctx, pos: int, nxt_op: Optional[int], labels: dict[int, str],
     if op == 0x4A:
         return [{"op": "look_at", "a": ctx.ent(ctx.u32(pos + 1)), "b": ctx.ent(ctx.u32(pos + 5))}], sz
     if op == 0x29:
-        return [{"op": "companion", "a": sc[pos + 1], "entity": ctx.ent(ctx.u32(pos + 2)), "b": sc[pos + 6]}], sz
+        return [{"op": "request_wait", "a": sc[pos + 1], "entity": ctx.ent(ctx.u32(pos + 2)), "b": sc[pos + 6]}], sz   # CodeREQEW: b = slot of the entity's event table
     if op == 0x53:
         return [{"op": "wait_task", "a": ctx.ent(ctx.u32(pos + 1)), "b": ctx.ent(ctx.u32(pos + 5)), **_tag(sc, pos + 9)}], sz
     if op in (0x5B, 0x66):
@@ -1122,7 +1124,7 @@ def decompile_loaded(actors, blobs, names, zf, actor_id: int, event_id: int, whi
         op = st.get("op")
         for k in ("a", "b", "target", "entity", "from", "to", "speaker"):
             v = st.get(k)
-            if op in ("action", "wait_task", "schedule", "look", "look_at", "look_talk", "companion", "task", "effect", "effect_bare",
+            if op in ("action", "wait_task", "schedule", "look", "look_at", "look_talk", "companion", "request_wait", "task", "effect", "effect_bare",
                       "render_flag", "load_wait", "ui_flag", "calibrate", "print2") and isinstance(v, str):
                 ent_entry(v)
         if op in ("action", "wait_task", "schedule", "task") and st.get("tag"):

--- a/src/xi/event/xi_typed.py
+++ b/src/xi/event/xi_typed.py
@@ -20,7 +20,7 @@ ours. A table entry is keyed by opcode, or by (opcode, size) when the size selec
 TYPED: dict = {
     # scheduler requests (XiEvent::ReqSet helpers): a = priority byte, b = request index
     0x27: ("request", [("a", "u8"), ("entity", "ent"), ("b", "u8")]),
-    0x2A: ("request_wait", [("a", "u8"), ("entity", "ent")]),
+    0x2A: ("request_level", [("a", "u8"), ("entity", "ent")]),      # GetReqLevel: a query, never waits
     # entity render flags: the byte is the new value / mask for Flags0 / Flags2 / Flags3
     0x2F: ("render_flags0", [("flag", "u8"), ("entity", "ent")]),
     0x7C: ("render_flags2", [("flag", "u8"), ("entity", "ent")]),
@@ -38,7 +38,7 @@ TYPED: dict = {
     0x76: ("wait_render", [("entity", "ent")]),      # yields on Render.Flags0 / Flags3
     0x5E: ("stop_action", [("tag", "tag")]),         # back to the idle motion
     0x7B: ("stop_talking", [("entity", "ent")]),     # NpcSpeechFrame = -1
-    0x6C: ("fade_color", [("entity", "ent"), ("a", "sel"), ("b", "sel")]),
+    0x6C: ("transparency", [("entity", "ent"), ("a", "sel"), ("b", "sel")]),   # CodeTRANSPAR
     0x9A: ("wait_music", []),
     0x30: ("continue_off", []),                      # ucoff_continue = 0
     0x78: ("reset_time", []),                        # game timer on, zone weather reset
@@ -259,6 +259,7 @@ def spec_for(op: int, size: int, sub: int = -1):
 def opcode_for(name: str, step: dict):
     """(opcode, fields) for a step by name: the form whose fields the step carries, where a
     ``bytes`` field must match the data length exactly; among several the largest form wins."""
+    name = ALIASES.get(name, name)
     def fits(fields) -> bool:
         for f in fields:
             fname, kind = f[0], f[1]
@@ -290,6 +291,63 @@ def opcode_for(name: str, step: dict):
                 if best is None or size < best[2]:
                     best = (key[0] if isinstance(key, tuple) else key, fields, size)
     return None if best is None else (best[0], best[1])
+
+
+# Step names that changed; the compiler accepts the old name and the decompiler emits the new one.
+ALIASES = {
+    "fade_color": "transparency",      # 0x6C, SE: CodeTRANSPAR
+    "companion": "request_wait",       # 0x29, SE: CodeREQEW (ReqSetWait): run a slot of another entity's table and wait
+}
+
+# Entity-state work selectors (XiEvent::getworkofs, 0x7F00-0x7F8B): runtime values of the event
+# entity (0x7F0x) and of the local player (0x7F8x). Positions are millimetres, headings are
+# enDirCli(rad) * 4096 / (2*pi); "flag25" is bit 25 of Render.Flags01. Carried as {"state": name}.
+STATE_SELECTORS = {
+    "event_x": 0x7F00, "event_z": 0x7F01, "event_y": 0x7F02, "event_dir": 0x7F03,
+    "event_job": 0x7F06, "event_race": 0x7F07, "event_level": 0x7F08, "event_server_id": 0x7F0A, "event_flag25": 0x7F0B,
+    "player_x": 0x7F80, "player_z": 0x7F81, "player_y": 0x7F82, "player_dir": 0x7F83,
+    "player_job": 0x7F86, "player_race": 0x7F87, "player_level": 0x7F88, "player_server_id": 0x7F8A, "player_flag25": 0x7F8B,
+}
+STATE_NAMES = {v: k for k, v in STATE_SELECTORS.items()}
+
+# Square Enix's own handler names (XiEvent::Code*), from the PS2 client's DWARF symbols via the
+# XiEvents notes and docs/reference/ps2_decomp_crosscheck.md. The 2003 switch ends at 0xA6.
+SE_NAMES = {
+    0x02: "CodeIF", 0x1F: "CodeMOVE", 0x23: "MESWAIT", 0x24: "CodeQUERY", 0x25: "CodeQUERYWAIT",
+    0x28: "CodeREQSW", 0x29: "CodeREQEW", 0x2C: "CodeSCHEDULOR", 0x2D: "CodeMAPSCHEDULOR", 0x31: "CodeSMOVE",
+    0x34: "XiZone::Open", 0x35: "XiZone::Open (no close)", 0x40: "CodeSETBITWORK", 0x41: "CodeGETBITWORK",
+    0x45: "CodeLOADSCHEDULER", 0x46: "CodeDEFCAMERA", 0x4A: "CodeDTURA", 0x50: "CodeENDSCHEDULOR",
+    0x51: "CodeENDMAPSCHEDULOR", 0x52: "CodeENDLOADSCHEDULER_Main", 0x53: "CodeWAITSCHEDULOR",
+    0x54: "CodeWAITMAPSCHEDULOR", 0x55: "CodeWAITLOADSCHEDULER_Main", 0x5A: "CodeMOVE2", 0x5B: "CodeLOADEXTSCHEDULERMain",
+    0x62: "CodeLOADEVENTSCHEDULER", 0x65: "CodeGETDISTANCEAA", 0x66: "CodeLOADEXTSCHEDULERMain", 0x6C: "CodeTRANSPAR",
+    0x6E: "CodeEMOT", 0x71: "CodeOPENPASSWIN", 0x72: "CodeGETWEATER", 0x73: "CodeMAGICSCHEDULOR", 0x75: "CodeLOADROOM",
+    0x7E: "CodeCHOCOBO", 0x7F: "CodeQUERYWAIT2", 0x80: "CodeLOADWAIT", 0x8B: "CodeSETEVENTMARK",
+    0x98: "XiZone::IsReadingExtData", 0x9F: "CodeLOADEVENTSCHEDULER2", 0xA0: "CodeWAITLOADSCHEDULER_Main",
+    0xA1: "CodeENDLOADSCHEDULER_Main", 0xA2: "CodeWAITLOADSCHEDULER_Main", 0xA3: "CodeENDLOADSCHEDULER_Main",
+}
+
+
+def render_doc() -> str:
+    """The markdown behind docs/events/typed_opcodes.md (python -c "from xi.event import xi_typed; print(xi_typed.render_doc())")."""
+    rows = []
+    for key, (nm, fields) in TYPED.items():
+        op = key if isinstance(key, int) else key[0]
+        form = "" if isinstance(key, int) else (f"sub {key[2]:02X}" if len(key) == 3 else f"size {key[1]}")
+        fl = ", ".join(f"`{f[0]}`:{f[1]}" + (f"[{f[2]}]" if f[1] == "bytes" else "") for f in fields)
+        rows.append((nm, op, form, fl))
+    rows.sort(key=lambda r: (r[0], r[1], r[2]))
+    out = ["## Typed retail opcodes (`xi_typed.TYPED`)", "",
+           "One table drives both directions: `xi event decompile` emits these steps and the compiler writes them back byte for byte. "
+           "Field kinds: `u8` / `u16` literal, `sel` selector (constant through `references[]` or a register), `reg` register, "
+           "`ent` entity id, `tag` scheduler tag, `name16` 16-byte name, `tbl` table label, `msg` dialog line, `bytes[n]` verbatim. "
+           "The SE column is Square Enix's handler name where the PS2 client's symbols give one (the 2003 client ends at `0xA6`).", "",
+           "| step | opcode | form | fields | SE handler |", "|---|---|---|---|---|"]
+    for nm, op, form, fl in rows:
+        out.append(f"| `{nm}` | `{op:02X}` | {form} | {fl} | {SE_NAMES.get(op, '')} |")
+    out += ["", "Old names still accepted by the compiler: " + ", ".join(f"`{a}` -> `{b}`" for a, b in sorted(ALIASES.items())) + ".", "",
+            "Entity-state selectors, carried as `{\"state\": name}` wherever a register is accepted: "
+            + ", ".join(f"`{k}` = `{v:04X}`" for k, v in STATE_SELECTORS.items()) + "."]
+    return "\n".join(out) + "\n"
 
 
 NAMES = sorted({nm for nm, _ in TYPED.values()})

--- a/tests/test_decompile.py
+++ b/tests/test_decompile.py
@@ -113,3 +113,16 @@ def test_replace_keeps_event_slot(root, zone, actor, event, slot):
     moved = [i for i, (x, y) in enumerate(zip(before.event_offsets, after.event_offsets)) if x != y]
     assert moved == [slot], moved
     assert bytes(after.scene_data[:len(before.scene_data)]) == bytes(before.scene_data)
+
+
+def test_state_selectors_and_aliases():
+    """0x7F00-0x7F8B selectors round-trip by name; renamed steps keep their old names as aliases."""
+    from xi.event import xi_typed, xi_compile, xi_decompile as D2
+    for name, sel in xi_typed.STATE_SELECTORS.items():
+        assert D2.Ctx.reg(sel) == {"state": name}
+        assert xi_compile._work_selector({"state": name}) == sel
+    for old, new in xi_typed.ALIASES.items():
+        assert xi_compile.STEP_DISPATCH[old] is xi_compile.STEP_DISPATCH[new]
+    assert xi_typed.opcode_for("fade_color", {"entity": "self", "a": 0, "b": 0})[0] == 0x6C
+    assert xi_typed.opcode_for("transparency", {"entity": "self", "a": 0, "b": 0})[0] == 0x6C
+    assert xi_typed.opcode_for("request_level", {"a": 0, "entity": "self"})[0] == 0x2A


### PR DESCRIPTION
## What changes

- **Entity-state selectors get names.** Work selectors `0x7F00`–`0x7F8B` (XiEvent::getworkofs: the event entity's and the local player's position, heading, job, race, level, server id and render bit 25) now decompile as `{"state": "player_race"}`, `{"state": "player_level"}`, `{"state": "event_x"}` and so on, and compile back to the same selector. Ru'Lude Gardens and Southern San d'Oria use them 484 times between them; a level gate that used to read as a raw selector now reads `if player_level < 31`. The list is in `xi_typed.STATE_SELECTORS` and documented in `typed_opcodes.md` and `authoring.md`.
- **SE's handler names.** `xi_typed.SE_NAMES` carries Square Enix's `XiEvent::Code*` names where the PS2 symbols give one, and `typed_opcodes.md` shows them as a column. The doc is now generated by `xi_typed.render_doc()` rather than by hand.
- **Two misleading step names fixed, old names kept as aliases.** `0x29` `companion` → `request_wait` (CodeREQEW: run a slot of another entity's event table and wait for it); the old `request_wait` on `0x2A` → `request_level` (GetReqLevel, a query that never waits); `0x6C` `fade_color` → `transparency` (CodeTRANSPAR). JSON written with the old names still compiles.

## Verification

- `pytest tests`: 33 passed, including a new test that round-trips every state selector by name and checks the aliases dispatch to the same handler.
- `xi event sweep 243 230 --check --jobs 8`: every retail event in both zones clean and stable (Ru'Lude 1190/1190, Southern San d'Oria in the same run), so the renamed steps and the named selectors are byte-exact.
- Existing authored events that use `companion` compile unchanged through the alias.

## Not included

Writing the two depth-of-field values in the camera keyframe (section 6 of the cross-check). The scene writer pads zeros there today, which is the default focus, and testing a change needs camera routes built through the editor.